### PR TITLE
Allow a custom type comment prefix.

### DIFF
--- a/ast27/Custom/typed_ast.c
+++ b/ast27/Custom/typed_ast.c
@@ -9,6 +9,7 @@
 #include "errcode.h"
 
 extern grammar _Ta27Parser_Grammar; /* from graminit.c */
+extern void tokenizer_register_type_comment_prefix(const char* pattern); /* from tokenizer.c */
 
 // from Python/bltinmodule.c
 static const char *
@@ -310,4 +311,14 @@ ast27_parse(PyObject *self, PyObject *args)
         return_value = ast27_parse_impl(source, filename, mode);
 
     return return_value;
+}
+
+PyObject *
+ast27_register_type_comment_prefix(PyObject *self, PyObject *args)
+{
+    const char* prefix;
+    if (!PyArg_ParseTuple(args, "s", &prefix))
+        return NULL;
+    tokenizer_register_type_comment_prefix(prefix);
+    return Py_None;
 }

--- a/ast27/Python/Python-ast.c
+++ b/ast27/Python/Python-ast.c
@@ -6850,9 +6850,13 @@ failed:
 }
 
 
+PyObject *ast27_register_type_comment_prefix(PyObject *self, PyObject *args);
 PyObject *ast27_parse(PyObject *self, PyObject *args);
 static PyMethodDef ast27_methods[] = {
-        {"parse",  ast27_parse, METH_VARARGS, "Parse string into typed AST."},
+        {"parse", ast27_parse,
+         METH_VARARGS, "Parse string into typed AST."},
+        {"register_type_comment_prefix", ast27_register_type_comment_prefix,
+         METH_VARARGS, "Register a prefix to treat as a typecomment."},
         {NULL, NULL, 0, NULL}
 };
 static struct PyModuleDef _astmodule27 = {

--- a/ast35/Custom/typed_ast.c
+++ b/ast35/Custom/typed_ast.c
@@ -9,6 +9,7 @@
 #include "errcode.h"
 
 extern grammar _Ta35Parser_Grammar; /* from graminit.c */
+extern void tokenizer_register_type_comment_prefix(const char* pattern); /* from tokenizer.c */
 
 // from Python/bltinmodule.c
 static const char *
@@ -319,4 +320,14 @@ ast35_parse(PyObject *self, PyObject *args)
         return_value = ast35_parse_impl(source, filename, mode);
 
     return return_value;
+}
+
+PyObject *
+ast35_register_type_comment_prefix(PyObject *self, PyObject *args)
+{
+    const char* prefix;
+    if (!PyArg_ParseTuple(args, "s", &prefix))
+        return NULL;
+    tokenizer_register_type_comment_prefix(prefix);
+    return Py_None;
 }

--- a/ast35/Python/Python-ast.c
+++ b/ast35/Python/Python-ast.c
@@ -7556,8 +7556,12 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
 
 
 PyObject *ast35_parse(PyObject *self, PyObject *args);
+PyObject *ast35_register_type_comment_prefix(PyObject *self, PyObject *args);
 static PyMethodDef ast35_methods[] = {
-    {"_parse",  ast35_parse, METH_VARARGS, "Parse string into typed AST."},
+    {"_parse", ast35_parse,
+     METH_VARARGS, "Parse string into typed AST."},
+    {"register_type_comment_prefix", ast35_register_type_comment_prefix,
+     METH_VARARGS, "Register a prefix to treat as a typecomment."},
     {NULL, NULL, 0, NULL}
 };
 static struct PyModuleDef _astmodule35 = {

--- a/typed_ast/ast27.py
+++ b/typed_ast/ast27.py
@@ -37,6 +37,13 @@ def parse(source, filename='<unknown>', mode='exec'):
     return _ast27.parse(source, filename, mode)
 
 
+def register_type_comment_prefix(prefix):
+    """
+    Register a keyword to scan for in comments, for things like: # type: ignore
+    """
+    return _ast27.register_type_comment_prefix(prefix)
+
+
 def literal_eval(node_or_string):
     """
     Safely evaluate an expression node or a string containing a Python

--- a/typed_ast/ast35.py
+++ b/typed_ast/ast35.py
@@ -46,6 +46,13 @@ def parse(source, filename='<unknown>', mode='exec'):
     return _ast35._parse(source, filename, mode)
 
 
+def register_type_comment_prefix(prefix):
+    """
+    Register a keyword to scan for in comments, for things like: # type: ignore
+    """
+    return _ast27.register_type_comment_prefix(prefix)
+
+
 def literal_eval(node_or_string):
     """
     Safely evaluate an expression node or a string containing a Python


### PR DESCRIPTION
Instead of hardcoding it, we expect callers to explicitly do something like

```
ast27.register_type_comment_prefix("# type: ")
```

before parsing.

This is the typed_ast counterpiece to https://github.com/python/mypy/pull/2030.
