### PR TITLE
Fix segfault on f-string

### DIFF
--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -213,7 +213,7 @@ err_free(perrdetail *err)
 
 // copy of PyParser_ASTFromStringObject in Python/pythonrun.c
 /* Preferred access to parser is through AST. */
-static mod_ty
+mod_ty
 string_object_to_c_ast(const char *s, PyObject *filename, int start,
                              PyCompilerFlags *flags, int feature_version,
                              PyArena *arena)


### PR DESCRIPTION
Fixes #30 

The fix is very straightforward, it looks like it was just an oversight.

(Note that the corresponding Python function is public, so that I also removed ``static`` declaration here)