### PR TITLE
Fix shadow-compatible-local warnings

### DIFF
--- a/ast27/Python/Python-ast.c
+++ b/ast27/Python/Python-ast.c
@@ -3959,10 +3959,10 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                         targets = asdl_seq_new(len, arena);
                         if (targets == NULL) goto failed;
                         for (i = 0; i < len; i++) {
-                                expr_ty value;
-                                res = obj2ast_expr(PyList_GET_ITEM(tmp, i), &value, arena);
+                                expr_ty val;
+                                res = obj2ast_expr(PyList_GET_ITEM(tmp, i), &val, arena);
                                 if (res != 0) goto failed;
-                                asdl_seq_SET(targets, i, value);
+                                asdl_seq_SET(targets, i, val);
                         }
                         Py_XDECREF(tmp);
                         tmp = NULL;

--- a/ast3/Python/Python-ast.c
+++ b/ast3/Python/Python-ast.c
@@ -4846,14 +4846,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             targets = _Ta3_asdl_seq_new(len, arena);
             if (targets == NULL) goto failed;
             for (i = 0; i < len; i++) {
-                expr_ty value;
-                res = obj2ast_expr(PyList_GET_ITEM(tmp, i), &value, arena);
+                expr_ty val;
+                res = obj2ast_expr(PyList_GET_ITEM(tmp, i), &val, arena);
                 if (res != 0) goto failed;
                 if (len != PyList_GET_SIZE(tmp)) {
                     PyErr_SetString(PyExc_RuntimeError, "Assign field \"targets\" changed size during iteration");
                     goto failed;
                 }
-                asdl_seq_SET(targets, i, value);
+                asdl_seq_SET(targets, i, val);
             }
             Py_CLEAR(tmp);
         } else {


### PR DESCRIPTION
The shadow-compatible-local warnings are reported when I am compiling the source code. Please consider this PR for fixing it.

- Change the conflicting naming in the inner block to avoid misusing it and causing bugs in the future.