### PR TITLE
Make Travis badge show build status on master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Typed AST
 
-[![Build Status](https://travis-ci.org/python/typed_ast.svg)](https://travis-ci.org/python/typed_ast)
+[![Build Status](https://travis-ci.org/python/typed_ast.svg?branch=master)](https://travis-ci.org/python/typed_ast)
 [![Chat at https://gitter.im/python/typed_ast](https://badges.gitter.im/python/typed_ast.svg)](https://gitter.im/python/typed_ast)
 
 `typed_ast` is a Python 3 package that provides a Python 2.7 and Python 3


### PR DESCRIPTION
Currently, the Travis badge shows the status of the latest build, regardless of the branch.

For instance, if someone is working on a feature and has broken some tests, the badge in the README on master branch will be red.

This is a followup to https://github.com/python/mypy/pull/3690