### PR TITLE
Vs2010 compilation support (Python 3.3/3.4 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ parser similar to the standard `ast` library.  Unlike `ast`, the parsers in
 comments and are independent of the version of Python under which they are run.
 The `typed_ast` parsers produce the standard Python AST (plus type comments),
 and are both fast and correct, as they are based on the CPython 2.7 and 3.6
-parsers.  `typed_ast` runs on Python 3.3-3.6 on Linux and OS X, and on Python
-3.5-3.6 on Windows.
+parsers.  `typed_ast` runs on Python 3.3-3.6 on Linux, OS X and Windows.
 
 ## Submodules
 ### ast3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@ environment:
   matrix:
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python33-x64"
+      DISTUTILS_USE_SDK: 1
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 environment:
-
   matrix:
-
     # For Python versions available on Appveyor, see
     # http://www.appveyor.com/docs/installed-software#python
-
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python34-x64"
+      DISTUTILS_USE_SDK: 1
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"

--- a/ast27/Custom/typed_ast.c
+++ b/ast27/Custom/typed_ast.c
@@ -239,6 +239,7 @@ string_object_to_py_ast(const char *str, PyObject *filename, int start,
                        PyCompilerFlags *flags)
 {
     mod_ty mod;
+    PyObject *result;
     PyArena *arena = PyArena_New();
     if (arena == NULL)
         return NULL;
@@ -249,7 +250,7 @@ string_object_to_py_ast(const char *str, PyObject *filename, int start,
         return NULL;
     }
 
-    PyObject *result = Ta27AST_mod2obj(mod);
+    result = Ta27AST_mod2obj(mod);
     PyArena_Free(arena);
     return result;
 }

--- a/ast27/Parser/tokenizer.c
+++ b/ast27/Parser/tokenizer.c
@@ -1352,6 +1352,10 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
         };
         char cbuf[80];
         char *tp, **cp;
+
+        /* used for type comment checks */
+        const char *prefix, *p, *type_start;
+
         tp = cbuf;
         do {
             *tp++ = c = tok_nextc(tok);
@@ -1375,9 +1379,9 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
         }
         while (c != EOF && c != '\n')
             c = tok_nextc(tok);
-
+            
         /* check for type comment */
-        const char *prefix, *p, *type_start;
+        
         p = tok->start;
         prefix = type_comment_prefix;
         while (*prefix && p < tok->cur) {

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -2303,6 +2303,7 @@ ast_for_class_bases(struct compiling *c, const node* n)
 static stmt_ty
 ast_for_expr_stmt(struct compiling *c, const node *n)
 {
+    int num;
     REQ(n, expr_stmt);
     /* expr_stmt: testlist (augassign (yield_expr|testlist)
                 | ('=' (yield_expr|testlist))* [TYPE_COMMENT])
@@ -2311,7 +2312,7 @@ ast_for_expr_stmt(struct compiling *c, const node *n)
                 | '<<=' | '>>=' | '**=' | '//='
        test: ... here starts the operator precendence dance
      */
-    int num = NCH(n);
+    num = NCH(n);
 
     if (num == 1 || (num == 2 && TYPE(CHILD(n, 1)) == TYPE_COMMENT)) {
         expr_ty e = ast_for_testlist(c, CHILD(n, 0));
@@ -3516,12 +3517,13 @@ parsenumber(struct compiling *c, const char *s)
                 /* Make a copy without the trailing 'L' */
                 size_t len = end - s  + 1;
                 char *copy = malloc(len);
+                PyObject *result;
                 if (copy == NULL)
                         return PyErr_NoMemory();
                 memcpy(copy, s, len);
                 copy[len - 1] = '\0';
                 old_style_octal = len > 2 && copy[0] == '0' && copy[1] >= '0' && copy[1] <= '9';
-                PyObject *result = PyLong_FromString(copy, (char **)0, old_style_octal ? 8 : 0);
+                result = PyLong_FromString(copy, (char **)0, old_style_octal ? 8 : 0);
                 free(copy);
                 return result;
         }

--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -249,6 +249,7 @@ string_object_to_py_ast(const char *str, PyObject *filename, int start,
                        PyCompilerFlags *flags, int feature_version)
 {
     mod_ty mod;
+    PyObject *result;
     PyArena *arena = PyArena_New();
     if (arena == NULL)
         return NULL;
@@ -259,7 +260,7 @@ string_object_to_py_ast(const char *str, PyObject *filename, int start,
         return NULL;
     }
 
-    PyObject *result = Ta3AST_mod2obj(mod);
+    result = Ta3AST_mod2obj(mod);
     PyArena_Free(arena);
     return result;
 }

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -2274,6 +2274,7 @@ ast_for_atom(struct compiling *c, const node *n)
         return str;
     }
     case NUMBER: {
+        PyObject *pynum;
         const char *s = STR(ch);
         /* Underscores in numeric literals are only allowed in Python 3.6 or greater */
         /* Check for underscores here rather than in parse_number so we can report a line number on error */
@@ -2282,7 +2283,7 @@ ast_for_atom(struct compiling *c, const node *n)
                     "Underscores in numeric literals are only supported in Python 3.6 and greater");
             return NULL;
         }
-        PyObject *pynum = parsenumber(c, s);
+        pynum = parsenumber(c, s);
         if (!pynum)
             return NULL;
 
@@ -3040,6 +3041,7 @@ ast_for_testlist(struct compiling *c, const node* n)
 static stmt_ty
 ast_for_expr_stmt(struct compiling *c, const node *n)
 {
+    int num;
     REQ(n, expr_stmt);
     /* expr_stmt: testlist_star_expr (annassign | augassign (yield_expr|testlist) |
                            ('=' (yield_expr|testlist_star_expr))* [TYPE_COMMENT])
@@ -3049,7 +3051,7 @@ ast_for_expr_stmt(struct compiling *c, const node *n)
                 | '<<=' | '>>=' | '**=' | '//='
        test: ... here starts the operator precedence dance
      */
-    int num = NCH(n);
+    num = NCH(n);
 
     if (num == 1 || (num == 2 && TYPE(CHILD(n, 1)) == TYPE_COMMENT)) {
         expr_ty e = ast_for_testlist(c, CHILD(n, 0));


### PR DESCRIPTION
MSVC 9's weird C99 implementation means that identifiers must be declared at the beginning of a scope. This refactors the code to support that. There are no functional changes to the parsing. I mostly did this out of an interest to see how hard it would be, turns out pretty simple 😄

This should also work for Python 3.3 (I can add it to the build matrix if desired).