### PR TITLE
Fix conversions.py2to3 on unicode strings

### DIFF
--- a/typed_ast/conversions.py
+++ b/typed_ast/conversions.py
@@ -218,7 +218,7 @@ class _AST2To3(ast27.NodeTransformer):
         if isinstance(s.s, bytes):
             return ast3.Bytes(s.s)
         else:
-            return ast3.Str(s.s)
+            return ast3.Str(s.s, s.kind)
 
     def visit_Num(self, n):
         new = self.generic_visit(n)


### PR DESCRIPTION
The introduction of string kinds in #49 missed updating the 2to3 visitor
for it. Update the `visit_Str` case to pass `s.kind` to `Str`.

Fixes #66.