### PR TITLE
Fix remaining calls to Str without a kind

### DIFF
--- a/typed_ast/ast27.py
+++ b/typed_ast/ast27.py
@@ -283,7 +283,7 @@ class NodeTransformer(NodeVisitor):
            def visit_Name(self, node):
                return copy_location(Subscript(
                    value=Name(id='data', ctx=Load()),
-                   slice=Index(value=Str(s=node.id)),
+                   slice=Index(value=Str(s=node.id, kind='')),
                    ctx=node.ctx
                ), node)
 

--- a/typed_ast/ast3.py
+++ b/typed_ast/ast3.py
@@ -53,8 +53,8 @@ def parse(source, filename='<unknown>', mode='exec', feature_version=LATEST_MINO
     fully supported for Python 3.5+ with partial support for Python 3.4.
     So, feature_version=3 or less are all equivalent to feature_version=4.
 
-    When feature_version=4, the parser will forbid the use of the async/await 
-    keywords and the '@' operator, but will not forbid the use of PEP 448 
+    When feature_version=4, the parser will forbid the use of the async/await
+    keywords and the '@' operator, but will not forbid the use of PEP 448
     additional unpacking generalizations, which were also added in Python 3.5.
     """
     return _ast3._parse(source, filename, mode, feature_version)
@@ -306,7 +306,7 @@ class NodeTransformer(NodeVisitor):
            def visit_Name(self, node):
                return copy_location(Subscript(
                    value=Name(id='data', ctx=Load()),
-                   slice=Index(value=Str(s=node.id)),
+                   slice=Index(value=Str(s=node.id, kind='')),
                    ctx=node.ctx
                ), node)
 

--- a/typed_ast/conversions.py
+++ b/typed_ast/conversions.py
@@ -106,7 +106,8 @@ class _AST2To3(ast27.NodeTransformer):
             keywords.append(ast3.keyword("file", self.visit(n.dest)))
 
         if not n.nl:
-            keywords.append(ast3.keyword("end", ast3.Str(" ", lineno=n.lineno, col_offset=-1)))
+            keywords.append(ast3.keyword("end",
+                                         ast3.Str(s=" ", kind='', lineno=n.lineno, col_offset=-1)))
 
         return ast3.Expr(ast3.Call(ast3.Name("print", ast3.Load(), lineno=n.lineno, col_offset=-1),
                                    self.visit(n.values),


### PR DESCRIPTION
There is one in the conversions.py2to3 case for a print statement that
suppresses the newline, which causes crashes.

Additionally there are two examples in documentation that leave it out.