### PR TITLE
Bump version to 1.2.0-dev

### DIFF
--- a/typed_ast/__init__.py
+++ b/typed_ast/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.1.2-dev"
+__version__ = "1.2.0-dev"


### PR DESCRIPTION
The addition of a kind argument to Str should have come with a minor
version bump (since it is backwards incompatible).

The plan is to bump the version, and then to pull the busted 1.1.1.