### PR TITLE
Add support for Python 3.7 (cheaply)

### DIFF
--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -222,12 +222,13 @@ string_object_to_c_ast(const char *s, PyObject *filename, int start,
     PyCompilerFlags localflags;
     perrdetail err;
     int iflags = PARSER_FLAGS(flags);
+    node *n;
 
     if (feature_version >= 7)
         iflags |= PyPARSE_ALWAYS_ASYNC;
-    node *n = Ta3Parser_ParseStringObject(s, filename,
-                                         &_Ta3Parser_Grammar, start, &err,
-                                         &iflags);
+    n = Ta3Parser_ParseStringObject(s, filename,
+                                    &_Ta3Parser_Grammar, start, &err,
+                                    &iflags);
     if (flags == NULL) {
         localflags.cf_flags = 0;
         flags = &localflags;

--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -223,6 +223,8 @@ string_object_to_c_ast(const char *s, PyObject *filename, int start,
     perrdetail err;
     int iflags = PARSER_FLAGS(flags);
 
+    if (feature_version >= 7)
+        iflags |= PyPARSE_ALWAYS_ASYNC;
     node *n = Ta3Parser_ParseStringObject(s, filename,
                                          &_Ta3Parser_Grammar, start, &err,
                                          &iflags);

--- a/ast3/Include/parsetok.h
+++ b/ast3/Include/parsetok.h
@@ -34,6 +34,7 @@ typedef struct {
 
 #define PyPARSE_IGNORE_COOKIE 0x0010
 #define PyPARSE_BARRY_AS_BDFL 0x0020
+#define PyPARSE_ALWAYS_ASYNC  0x8000
 
 extern node * Ta3Parser_ParseString(const char *, grammar *, int,
                                               perrdetail *);

--- a/ast3/Parser/parsetok.c
+++ b/ast3/Parser/parsetok.c
@@ -64,6 +64,8 @@ Ta3Parser_ParseStringObject(const char *s, PyObject *filename,
     Py_INCREF(err_ret->filename);
     tok->filename = err_ret->filename;
 #endif
+    if (*flags & PyPARSE_ALWAYS_ASYNC)
+        tok->async_always = 1;
     return parsetok(tok, g, start, err_ret, flags);
 }
 

--- a/ast3/Parser/tokenizer.c
+++ b/ast3/Parser/tokenizer.c
@@ -171,6 +171,7 @@ tok_new(void)
     tok->async_def = 0;
     tok->async_def_indent = 0;
     tok->async_def_nl = 0;
+    tok->async_always = 0;
 
     return tok;
 }
@@ -1616,7 +1617,7 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
         /* async/await parsing block. */
         if (tok->cur - tok->start == 5) {
             /* Current token length is 5. */
-            if (tok->async_def) {
+            if (tok->async_always || tok->async_def) {
                 /* We're inside an 'async def' function. */
                 if (memcmp(tok->start, "async", 5) == 0) {
                     return ASYNC;

--- a/ast3/Parser/tokenizer.h
+++ b/ast3/Parser/tokenizer.h
@@ -72,6 +72,7 @@ struct tok_state {
     int async_def_indent; /* Indentation level of the outermost 'async def'. */
     int async_def_nl;     /* =1 if the outermost 'async def' had at least one
                              NEWLINE token after it. */
+    int async_always;     /* =1 if async/await are always keywords */
 };
 
 extern struct tok_state *Ta3Tokenizer_FromString(const char *, int);

--- a/ast3/tests/test_basics.py
+++ b/ast3/tests/test_basics.py
@@ -6,7 +6,7 @@ import _ast3
 
 # Lowest and highest supported Python 3 minor version (inclusive)
 MIN_VER = 4
-MAX_VER = 6
+MAX_VER = 7
 NEXT_VER = MAX_VER + 1
 
 

--- a/typed_ast/__init__.py
+++ b/typed_ast/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "1.2.1-dev"
+__version__ = "1.3.0.dev0"

--- a/typed_ast/ast3.py
+++ b/typed_ast/ast3.py
@@ -40,7 +40,7 @@
 import _ast3
 from _ast3 import *
 
-LATEST_MINOR_VERSION = 6
+LATEST_MINOR_VERSION = 7
 
 def parse(source, filename='<unknown>', mode='exec', feature_version=LATEST_MINOR_VERSION):
     """
@@ -56,6 +56,8 @@ def parse(source, filename='<unknown>', mode='exec', feature_version=LATEST_MINO
     When feature_version=4, the parser will forbid the use of the async/await
     keywords and the '@' operator, but will not forbid the use of PEP 448
     additional unpacking generalizations, which were also added in Python 3.5.
+
+    When feature_version>=7, 'async' and 'await' are always keywords.
     """
     return _ast3._parse(source, filename, mode, feature_version)
 


### PR DESCRIPTION
There is actually no syntactic difference between 3.6 and 3.7,
*except* that in 3.7 'async' and 'await' are always keywords.  So this
diff simply adds a check that forces these two to be
keywords when feature_version >= 7.

There is one place where the generated AST is different between 3.6
and 3.7: where 3.6 has
```
  comp_for: [ASYNC] 'for' exprlist 'in' or_test [comp_iter]
```
3.7 has
```
  sync_comp_for: 'for' exprlist 'in' or_test [comp_iter]
  comp_for: ['async'] sync_comp_for
```
However, changing the AST structure to conform to 3.7 would be a
backwards incompatible change to typed_ast, while the current change
is not backwards incompatible (it simply adds a new flag bit
definition).
(**UPDATE:** This is not an incompatibility since the returned AST is the same
-- the Grammar affects the concrete parse tree, which is never returned.)

Finally, a note for mypy specifically: when this version in installed,
using Python 3.7 with mypy will reject code that was previously (and
wrongly) not rejected: in particular code that uses 'async' or 'await'
as a non-keyword is invalid in Python 3.7, but mypy would not have
rejected that code with previous typed_ast versions.  Does this mean
we should bump the version to 1.3?  I don't know...