### PR TITLE
Fix await in functions with type comments

### DIFF
--- a/ast3/Parser/tokenizer.c
+++ b/ast3/Parser/tokenizer.c
@@ -1476,8 +1476,18 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
         }
     }
 
+    /* Peek ahead at the next character */
+    c = tok_nextc(tok);
+    tok_backup(tok, c);
+    /* Check if we are closing an async function */
     if (tok->async_def
         && !blankline
+        /* Due to some implementation artifacts of type comments,
+         * a TYPE_COMMENT at the start of a function won't set an
+         * indentation level and it will produce a NEWLINE after it.
+         * To avoid spuriously ending an async function due to this,
+         * wait until we have some non-newline char in front of us. */
+        && c != '\n'
         && tok->level == 0
         /* There was a NEWLINE after ASYNC DEF,
            so we're past the signature. */

--- a/ast3/tests/test_basics.py
+++ b/ast3/tests/test_basics.py
@@ -189,9 +189,9 @@ def test_ignores():
         assert [ti.lineno for ti in tree.type_ignores] == [2, 5]
 
 
-# TODO: type comment on new line (currently fails)
 asyncfunc = """\
-async def foo():  # type: () -> int
+async def foo():
+    # type: () -> int
     return await bar()
 """
 def test_asyncfunc():


### PR DESCRIPTION
It was caused by a somewhat gnarly tokenizer issue.

Fixes #76.