### PR TITLE
Fix f-string parsing to not think everything is a set

### DIFF
--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -227,7 +227,7 @@ Ta3Parser_SimpleParseStringFlagsFilename(const char *str, const char *filename,
 
 /* update compiler and parser flags based on feature version */
 void
-update_typed_ast_flags(PyCompilerFlags *flags, int *iflags, int feature_version)
+_Ta3Parser_UpdateFlags(PyCompilerFlags *flags, int *iflags, int feature_version)
 {
     *iflags = PARSER_FLAGS(flags);
     if (feature_version >= 7)
@@ -237,7 +237,7 @@ update_typed_ast_flags(PyCompilerFlags *flags, int *iflags, int feature_version)
 
 // copy of PyParser_ASTFromStringObject in Python/pythonrun.c
 /* Preferred access to parser is through AST. */
-mod_ty
+static mod_ty
 string_object_to_c_ast(const char *s, PyObject *filename, int start,
                              PyCompilerFlags *flags, int feature_version,
                              PyArena *arena)
@@ -252,7 +252,7 @@ string_object_to_c_ast(const char *s, PyObject *filename, int start,
         localflags.cf_flags = 0;
         flags = &localflags;
     }
-    update_typed_ast_flags(flags, &iflags, feature_version);
+    _Ta3Parser_UpdateFlags(flags, &iflags, feature_version);
     n = Ta3Parser_ParseStringObject(s, filename,
                                     &_Ta3Parser_Grammar, start, &err,
                                     &iflags);

--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -211,6 +211,30 @@ err_free(perrdetail *err)
     Py_CLEAR(err->filename);
 }
 
+// from Python/pythonrun.c
+node *
+Ta3Parser_SimpleParseStringFlagsFilename(const char *str, const char *filename,
+                                         int start, int flags)
+{
+    perrdetail err;
+    node *n = Ta3Parser_ParseStringFlagsFilename(str, filename,
+                            &_Ta3Parser_Grammar, start, &err, flags);
+    if (n == NULL)
+        err_input(&err);
+    err_free(&err);
+    return n;
+}
+
+/* update compiler and parser flags based on feature version */
+void
+update_typed_ast_flags(PyCompilerFlags *flags, int *iflags, int feature_version)
+{
+    *iflags = PARSER_FLAGS(flags);
+    if (feature_version >= 7)
+        *iflags |= PyPARSE_ASYNC_ALWAYS;
+    flags->cf_flags |= *iflags & PyCF_MASK;
+}
+
 // copy of PyParser_ASTFromStringObject in Python/pythonrun.c
 /* Preferred access to parser is through AST. */
 mod_ty
@@ -221,18 +245,17 @@ string_object_to_c_ast(const char *s, PyObject *filename, int start,
     mod_ty mod;
     PyCompilerFlags localflags;
     perrdetail err;
-    int iflags = PARSER_FLAGS(flags);
     node *n;
+    int iflags;
 
-    if (feature_version >= 7)
-        iflags |= PyPARSE_ASYNC_ALWAYS;
-    n = Ta3Parser_ParseStringObject(s, filename,
-                                    &_Ta3Parser_Grammar, start, &err,
-                                    &iflags);
     if (flags == NULL) {
         localflags.cf_flags = 0;
         flags = &localflags;
     }
+    update_typed_ast_flags(flags, &iflags, feature_version);
+    n = Ta3Parser_ParseStringObject(s, filename,
+                                    &_Ta3Parser_Grammar, start, &err,
+                                    &iflags);
     if (n) {
         flags->cf_flags |= iflags & PyCF_MASK;
         mod = Ta3AST_FromNodeObject(n, flags, filename, feature_version, arena);

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -4577,7 +4577,6 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     char *str;
     Py_ssize_t len;
     const char *s;
-    PyObject *fstring_name;
 
     assert(expr_end >= expr_start);
     assert(*(expr_start-1) == '{');
@@ -4624,11 +4623,7 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     str[0] = '{';
     str[len+1] = '}';
     fstring_fix_node_location(n, mod_n, str);
-    fstring_name = PyUnicode_FromString("<fstring>");
-    mod = string_object_to_c_ast(str, fstring_name,
-                                 Py_eval_input, &cf,
-                                 c->c_feature_version, c->c_arena);
-    Py_DECREF(fstring_name);
+    mod = Ta3AST_FromNode(mod_n, &cf, "<fstring>", c->c_feature_version, c->c_arena);
     PyMem_RawFree(str);
     Ta3Node_Free(mod_n);
     if (!mod)

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -74,7 +74,7 @@ static int validate_stmt(stmt_ty);
 static int validate_expr(expr_ty, expr_context_ty);
 
 void
-update_typed_ast_flags(PyCompilerFlags *flags, int *iflags, int feature_version);
+_Ta3Parser_UpdateFlags(PyCompilerFlags *flags, int *iflags, int feature_version);
 node *
 Ta3Parser_SimpleParseStringFlagsFilename(const char *str, const char *filename,
                                          int start, int flags);
@@ -4615,7 +4615,7 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     str[len+2] = 0;
 
     cf.cf_flags = PyCF_ONLY_AST;
-    update_typed_ast_flags(&cf, &iflags, c->c_feature_version);
+    _Ta3Parser_UpdateFlags(&cf, &iflags, c->c_feature_version);
     mod_n = Ta3Parser_SimpleParseStringFlagsFilename(str, "<fstring>",
                                                      Py_eval_input, iflags);
     if (!mod_n) {

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -73,10 +73,11 @@ static int validate_nonempty_seq(asdl_seq *, const char *, const char *);
 static int validate_stmt(stmt_ty);
 static int validate_expr(expr_ty, expr_context_ty);
 
-mod_ty
-string_object_to_c_ast(const char *s, PyObject *filename, int start,
-                       PyCompilerFlags *flags, int feature_version,
-                       PyArena *arena);
+void
+update_typed_ast_flags(PyCompilerFlags *flags, int *iflags, int feature_version);
+node *
+Ta3Parser_SimpleParseStringFlagsFilename(const char *str, const char *filename,
+                                         int start, int flags);
 
 static int
 validate_comprehension(asdl_seq *gens)
@@ -4577,6 +4578,7 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     char *str;
     Py_ssize_t len;
     const char *s;
+    int iflags = 0;
 
     assert(expr_end >= expr_start);
     assert(*(expr_start-1) == '{');
@@ -4613,8 +4615,9 @@ fstring_compile_expr(const char *expr_start, const char *expr_end,
     str[len+2] = 0;
 
     cf.cf_flags = PyCF_ONLY_AST;
-    mod_n = PyParser_SimpleParseStringFlagsFilename(str, "<fstring>",
-                                                    Py_eval_input, 0);
+    update_typed_ast_flags(&cf, &iflags, c->c_feature_version);
+    mod_n = Ta3Parser_SimpleParseStringFlagsFilename(str, "<fstring>",
+                                                     Py_eval_input, iflags);
     if (!mod_n) {
         PyMem_RawFree(str);
         return NULL;

--- a/ast3/tests/test_basics.py
+++ b/ast3/tests/test_basics.py
@@ -270,3 +270,12 @@ def test_convert_strs():
     assert tree.body[0].value.kind == ""
     assert tree.body[1].value.kind == "u"
     assert tree.body[2].value.kind == "b"
+
+simple_fstring = """\
+f'{5}'
+"""
+def test_simple_fstring():
+    for version in range(6, NEXT_VER):
+        tree = _ast3._parse(simple_fstring, "<fstring>", "exec", version)
+        assert isinstance(tree.body[0].value, _ast3.JoinedStr)
+        assert isinstance(tree.body[0].value.values[0].value, _ast3.Num)

--- a/ast3/tests/test_basics.py
+++ b/ast3/tests/test_basics.py
@@ -279,3 +279,13 @@ def test_simple_fstring():
         tree = _ast3._parse(simple_fstring, "<fstring>", "exec", version)
         assert isinstance(tree.body[0].value, _ast3.JoinedStr)
         assert isinstance(tree.body[0].value.values[0].value, _ast3.Num)
+
+# Test the interaction between versions and f strings
+await_fstring = """\
+f'1 + {f"{await}"}'
+"""
+def test_await_fstring():
+    # Should work on 6 but fail on 7
+    _ast3._parse(await_fstring, "<bad-f-string>", "exec", 6)
+    with pytest.raises(SyntaxError):
+        _ast3._parse(await_fstring, "<bad-f-string>", "exec", 7)


### PR DESCRIPTION
typed-ast has (for a while) done f-string weirdly, essentially parsing
the f string contents twice. This was dodgy but harmless until a 3.7
change tweaked the string that was being used for the second parse to
be enclosed by braces, which is causing typed_ast to think that every
value in an f-string is a set.

Restore things to working like cpython.