### PR TITLE
Fix memory leaks caused by type comment parsing

### DIFF
--- a/ast3/Parser/parsetok.c
+++ b/ast3/Parser/parsetok.c
@@ -302,6 +302,7 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
         }
 
         if (type == TYPE_IGNORE) {
+            PyObject_FREE(str);
             if (!growable_int_array_add(&type_ignores, tok->lineno)) {
                 err_ret->error = E_NOMEM;
                 break;

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -740,7 +740,12 @@ new_identifier(const char *n, struct compiling *c)
 static string
 new_type_comment(const char *s, struct compiling *c)
 {
-  return PyUnicode_DecodeUTF8(s, strlen(s), NULL);
+    PyObject *res = PyUnicode_DecodeUTF8(s, strlen(s), NULL);
+    if (PyArena_AddPyObject(c->c_arena, res) < 0) {
+        Py_DECREF(res);
+        return NULL;
+    }
+    return res;
 }
 #define NEW_TYPE_COMMENT(n) new_type_comment(STR(n), c)
 


### PR DESCRIPTION
Echoes https://github.com/python/cpython/pull/11728 (they were found
by the CPython refleak detector, see
https://bugs.python.org/issue35879).