### PR TITLE
Fix some broken asserts relating to handling of async keyword

### DIFF
--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -1815,8 +1815,7 @@ ast_for_async_funcdef(struct compiling *c, const node *n, asdl_seq *decorator_se
 {
     /* async_funcdef: 'async' funcdef */
     REQ(n, async_funcdef);
-    REQ(CHILD(n, 0), NAME);
-    assert(strcmp(STR(CHILD(n, 0)), "async") == 0);
+    REQ(CHILD(n, 0), ASYNC);
     REQ(CHILD(n, 1), funcdef);
 
     return ast_for_funcdef_impl(c, n, decorator_seq,
@@ -1837,8 +1836,7 @@ ast_for_async_stmt(struct compiling *c, const node *n)
 {
     /* async_stmt: 'async' (funcdef | with_stmt | for_stmt) */
     REQ(n, async_stmt);
-    REQ(CHILD(n, 0), NAME);
-    assert(strcmp(STR(CHILD(n, 0)), "async") == 0);
+    REQ(CHILD(n, 0), ASYNC);
 
     switch (TYPE(CHILD(n, 1))) {
         case funcdef:
@@ -1956,8 +1954,7 @@ count_comp_fors(struct compiling *c, const node *n)
     n_fors++;
     REQ(n, comp_for);
     if (NCH(n) == 2) {
-        REQ(CHILD(n, 0), NAME);
-        assert(strcmp(STR(CHILD(n, 0)), "async") == 0);
+        REQ(CHILD(n, 0), ASYNC);
         n = CHILD(n, 1);
     }
     else if (NCH(n) == 1) {
@@ -2042,8 +2039,7 @@ ast_for_comprehension(struct compiling *c, const node *n)
 
         if (NCH(n) == 2) {
             is_async = 1;
-            REQ(CHILD(n, 0), NAME);
-            assert(strcmp(STR(CHILD(n, 0)), "async") == 0);
+            REQ(CHILD(n, 0), ASYNC);
             sync_n = CHILD(n, 1);
         }
         else {


### PR DESCRIPTION
typed_ast reintroduces ASYNC as a token after cpython 3.7 removed it.
Fix asserts that still wanted it to be a NAME.