### PR TITLE
Distribute the tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include ast27 *.h
 recursive-include ast3 *.h
+recursive-include ast3/tests *.py
 include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup (name = 'typed-ast',
            'Programming Language :: Python :: 3.7',
            'Topic :: Software Development',
        ],
-       packages = ['typed_ast'],
+       packages = ['typed_ast', 'typed_ast.tests'],
+       package_dir={ 'typed_ast.tests': 'ast3/tests' },
        ext_package='typed_ast',
        ext_modules = [_ast27, _ast3])


### PR DESCRIPTION
Patch from the Debian package for typed_ast, we use this to run the tests at build time and post-install. With this PR `typed_ast` users can also run the tests post-install and from any directory:

`python -m pytest --pyargs typed_ast`