### PR TITLE
Fix two out-of-bounds array reads

### DIFF
--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -1445,7 +1445,7 @@ handle_keywordonly_args(struct compiling *c, const node *n, int start,
                     goto error;
                 asdl_seq_SET(kwonlyargs, j++, arg);
                 i += 1; /* the name */
-                if (TYPE(CHILD(n, i)) == COMMA)
+                if (i < NCH(n) && TYPE(CHILD(n, i)) == COMMA)
                     i += 1; /* the comma, if present */
                 break;
             case TYPE_COMMENT:
@@ -1644,7 +1644,7 @@ ast_for_arguments(struct compiling *c, const node *n)
                 if (!kwarg)
                     return NULL;
                 i += 2; /* the double star and the name */
-                if (TYPE(CHILD(n, i)) == COMMA)
+                if (i < NCH(n) && TYPE(CHILD(n, i)) == COMMA)
                     i += 1; /* the comma, if present */
                 break;
             case TYPE_COMMENT:


### PR DESCRIPTION
The patch is taken from a commit to the CPython repo with the message:

> bpo-36495: Fix two out-of-bounds array reads (GH-12641)
> 
> Research and fix by @bradlarsen.

Some code I have triggered segmentation fault when I run pylint on it. With this patch, I don't get segmentation fault anylonger.

Backtrace from GDB:
#0  0x00001ff4e48a883b in ast_for_arguments () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#1  0x00001ff4e48ac4c0 in ast_for_funcdef_impl () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#2  0x00001ff4e48ac315 in ast_for_suite () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#3  0x00001ff4e48abd1e in ast_for_classdef () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#4  0x00001ff4e48a22c7 in Ta3AST_FromNodeObject () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#5  0x00001ff4e48c4f93 in ast3_parse () from $HOME/.local/lib/python3.6/site-packages/typed_ast/_ast3.so
#6  0x00001ff550af508a in _PyCFunction_FastCallDict () from /usr/local/lib/libpython3.6m.so.0.0
#7  0x00001ff550b86798 in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#8  0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#9  0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#10 0x00001ff550b88081 in _PyFunction_FastCallDict () from /usr/local/lib/libpython3.6m.so.0.0
#11 0x00001ff550a9dd3d in _PyObject_FastCallDict () from /usr/local/lib/libpython3.6m.so.0.0
#12 0x00001ff550bf8f76 in partial_call () from /usr/local/lib/libpython3.6m.so.0.0
#13 0x00001ff550a9ddea in _PyObject_FastCallDict () from /usr/local/lib/libpython3.6m.so.0.0
#14 0x00001ff550b86765 in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#15 0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#16 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#17 0x00001ff550b87cbb in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#18 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#19 0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#20 0x00001ff550b87d46 in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#21 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#22 0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#23 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#24 0x00001ff550b87cbb in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#25 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#26 0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#27 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#28 0x00001ff550b87cbb in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#29 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#30 0x00001ff550b835c9 in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#31 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#32 0x00001ff550b87cbb in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#33 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#34 0x00001ff550b80c0e in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#35 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
#36 0x00001ff550b87cbb in fast_function () from /usr/local/lib/libpython3.6m.so.0.0
#37 0x00001ff550b8676c in call_function () from /usr/local/lib/libpython3.6m.so.0.0
#38 0x00001ff550b835c9 in _PyEval_EvalFrameDefault () from /usr/local/lib/libpython3.6m.so.0.0
#39 0x00001ff550b87168 in _PyEval_EvalCodeWithName () from /usr/local/lib/libpython3.6m.so.0.0
