### PR TITLE
Don't rely on Python's pgenheaders.h

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8-dev
 
 script:
   - pytest

--- a/ast27/Include/pgenheaders.h
+++ b/ast27/Include/pgenheaders.h
@@ -1,0 +1,10 @@
+#ifndef DUMMY_Py_PGENHEADERS_H
+#define DUMMY_Py_PGENHEADERS_H
+
+/* pgenheaders.h is included by a bunch of files but nothing in it is
+ * used except for the Python.h import, and it was removed in Python
+ * 3.8. Since some of those files are generated we provide a dummy
+ * pgenheaders.h. */
+#include "Python.h"
+
+#endif /* !DUMMY_Py_PGENHEADERS_H */

--- a/ast3/Include/pgenheaders.h
+++ b/ast3/Include/pgenheaders.h
@@ -1,0 +1,10 @@
+#ifndef DUMMY_Py_PGENHEADERS_H
+#define DUMMY_Py_PGENHEADERS_H
+
+/* pgenheaders.h is included by a bunch of files but nothing in it is
+ * used except for the Python.h import, and it was removed in Python
+ * 3.8. Since some of those files are generated we provide a dummy
+ * pgenheaders.h. */
+#include "Python.h"
+
+#endif /* !DUMMY_Py_PGENHEADERS_H */


### PR DESCRIPTION
It turns out we don't need anything from it anyways other than the
import of Python.h. Since some of the files that import it are
generated, I added dummy pgenheaders.h instead of changing the
importing files.