### PR TITLE
Support text appearing after "# type: ignore"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Generated files
+# https://github.com/github/linguist#generated-code
+ast3/Include/graminit.h          linguist-generated=true
+ast3/Python/graminit.h           linguist-generated=true
+ast3/Include/Python-ast.h        linguist-generated=true
+ast3/Python/Python-ast.c         linguist-generated=true
+ast3/Include/token.h             linguist-generated=true
+ast3/Lib/token.py                linguist-generated=true
+ast3/Parser/token.c              linguist-generated=true
+ast27/Include/graminit.h         linguist-generated=true
+ast27/Python/graminit.h          linguist-generated=true
+ast27/Include/Python-ast.h       linguist-generated=true
+ast27/Python/Python-ast.c        linguist-generated=true
+ast27/Include/token.h            linguist-generated=true
+ast27/Lib/token.py               linguist-generated=true
+ast27/Parser/token.c             linguist-generated=true

--- a/ast27/Include/Python-ast.h
+++ b/ast27/Include/Python-ast.h
@@ -387,6 +387,7 @@ struct _type_ignore {
         union {
                 struct {
                         int lineno;
+                        string tag;
                 } TypeIgnore;
                 
         } v;
@@ -540,8 +541,8 @@ arguments_ty _Ta27_arguments(asdl_seq * args, identifier vararg, identifier kwar
 keyword_ty _Ta27_keyword(identifier arg, expr_ty value, PyArena *arena);
 #define alias(a0, a1, a2) _Ta27_alias(a0, a1, a2)
 alias_ty _Ta27_alias(identifier name, identifier asname, PyArena *arena);
-#define TypeIgnore(a0, a1) _Ta27_TypeIgnore(a0, a1)
-type_ignore_ty _Ta27_TypeIgnore(int lineno, PyArena *arena);
+#define TypeIgnore(a0, a1, a2) _Ta27_TypeIgnore(a0, a1, a2)
+type_ignore_ty _Ta27_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 PyObject* Ta27AST_mod2obj(mod_ty t);
 mod_ty Ta27AST_obj2mod(PyObject* ast, PyArena* arena, int mode);

--- a/ast27/Parser/Python.asdl
+++ b/ast27/Parser/Python.asdl
@@ -10,7 +10,7 @@ module Python version "$Revision$"
 	    -- not really an actual node but useful in Jython's typesystem.
 	    | Suite(stmt* body)
 
-	stmt = FunctionDef(identifier name, arguments args, 
+	stmt = FunctionDef(identifier name, arguments args,
                             stmt* body, expr* decorator_list, string? type_comment)
 	      | ClassDef(identifier name, expr* bases, stmt* body, expr* decorator_list)
 	      | Return(expr? value)
@@ -78,7 +78,7 @@ module Python version "$Revision$"
 	     | Attribute(expr value, identifier attr, expr_context ctx)
 	     | Subscript(expr value, slice slice, expr_context ctx)
 	     | Name(identifier id, expr_context ctx)
-	     | List(expr* elts, expr_context ctx) 
+	     | List(expr* elts, expr_context ctx)
 	     | Tuple(expr* elts, expr_context ctx)
 
 	      -- col_offset is the byte offset in the utf8 string the parser uses
@@ -86,13 +86,13 @@ module Python version "$Revision$"
 
 	expr_context = Load | Store | Del | AugLoad | AugStore | Param
 
-	slice = Ellipsis | Slice(expr? lower, expr? upper, expr? step) 
-	      | ExtSlice(slice* dims) 
-	      | Index(expr value) 
+	slice = Ellipsis | Slice(expr? lower, expr? upper, expr? step)
+	      | ExtSlice(slice* dims)
+	      | Index(expr value)
 
-	boolop = And | Or 
+	boolop = And | Or
 
-	operator = Add | Sub | Mult | Div | Mod | Pow | LShift 
+	operator = Add | Sub | Mult | Div | Mod | Pow | LShift
                  | RShift | BitOr | BitXor | BitAnd | FloorDiv
 
 	unaryop = Invert | Not | UAdd | USub
@@ -109,7 +109,7 @@ module Python version "$Revision$"
 	-- It is either an empty list or a list with length equal to the number of
 	-- args (including varargs and kwargs, if present) and with members set to the
 	-- string of each arg's type comment, if present, or None otherwise.
-	arguments = (expr* args, identifier? vararg, 
+	arguments = (expr* args, identifier? vararg,
 		     identifier? kwarg, expr* defaults, string* type_comments)
 
         -- keyword arguments supplied to call
@@ -118,5 +118,5 @@ module Python version "$Revision$"
         -- import name with optional 'as' alias.
         alias = (identifier name, identifier? asname)
 
-  type_ignore = TypeIgnore(int lineno)
+  type_ignore = TypeIgnore(int lineno, string tag)
 }

--- a/ast27/Parser/parsetok.c
+++ b/ast27/Parser/parsetok.c
@@ -188,7 +188,8 @@ growable_comment_array_add(growable_comment_array *arr, int lineno, char *commen
 
 static void
 growable_comment_array_deallocate(growable_comment_array *arr) {
-    for (unsigned i = 0; i < arr->num_items; i++) {
+    unsigned i;
+    for (i = 0; i < arr->num_items; i++) {
         PyObject_FREE(arr->items[i].comment);
     }
     free(arr->items);

--- a/ast27/Parser/parsetok.c
+++ b/ast27/Parser/parsetok.c
@@ -152,12 +152,16 @@ warn(const char *msg, const char *filename, int lineno)
 
 
 typedef struct {
-    int *items;
+    struct {
+        int lineno;
+        char *comment;
+    } *items;
     size_t size;
     size_t num_items;
-} growable_int_array;
+} growable_comment_array;
 
-int growable_int_array_init(growable_int_array *arr, size_t initial_size) {
+static int
+growable_comment_array_init(growable_comment_array *arr, size_t initial_size) {
     assert(initial_size > 0);
     arr->items = malloc(initial_size * sizeof(*arr->items));
     arr->size = initial_size;
@@ -166,20 +170,27 @@ int growable_int_array_init(growable_int_array *arr, size_t initial_size) {
     return arr->items != NULL;
 }
 
-int growable_int_array_add(growable_int_array *arr, int item) {
+static int
+growable_comment_array_add(growable_comment_array *arr, int lineno, char *comment) {
     if (arr->num_items >= arr->size) {
         arr->size *= 2;
         arr->items = realloc(arr->items, arr->size * sizeof(*arr->items));
-        if (!arr->items)
+        if (!arr->items) {
             return 0;
+        }
     }
 
-    arr->items[arr->num_items] = item;
+    arr->items[arr->num_items].lineno = lineno;
+    arr->items[arr->num_items].comment = comment;
     arr->num_items++;
     return 1;
 }
 
-void growable_int_array_deallocate(growable_int_array *arr) {
+static void
+growable_comment_array_deallocate(growable_comment_array *arr) {
+    for (unsigned i = 0; i < arr->num_items; i++) {
+        PyObject_FREE(arr->items[i].comment);
+    }
     free(arr->items);
 }
 
@@ -195,8 +206,8 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
     node *n;
     int started = 0;
 
-    growable_int_array type_ignores;
-    if (!growable_int_array_init(&type_ignores, 10)) {
+    growable_comment_array type_ignores;
+    if (!growable_comment_array_init(&type_ignores, 10)) {
         err_ret->error = E_NOMEM;
         Ta27Tokenizer_Free(tok);
         return NULL;
@@ -264,7 +275,7 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
             col_offset = -1;
 
         if (type == TYPE_IGNORE) {
-            if (!growable_int_array_add(&type_ignores, tok->lineno)) {
+            if (!growable_comment_array_add(&type_ignores, tok->lineno, str)) {
                 err_ret->error = E_NOMEM;
                 break;
             }
@@ -297,14 +308,22 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
             REQ(ch, ENDMARKER);
 
             for (i = 0; i < type_ignores.num_items; i++) {
-                Ta27Node_AddChild(ch, TYPE_IGNORE, NULL, type_ignores.items[i], 0);
+                int res = Ta27Node_AddChild(ch, TYPE_IGNORE, type_ignores.items[i].comment,
+                                            type_ignores.items[i].lineno, 0);
+                if (res != 0) {
+                    err_ret->error = res;
+                    Ta27Node_Free(n);
+                    n = NULL;
+                    break;
+                }
+                type_ignores.items[i].comment = NULL;
             }
         }
-        growable_int_array_deallocate(&type_ignores);
-
     }
     else
         n = NULL;
+
+    growable_comment_array_deallocate(&type_ignores);
 
 #ifdef PY_PARSER_REQUIRES_FUTURE_KEYWORD
     *flags = ps->p_flags;

--- a/ast27/Parser/tokenizer.c
+++ b/ast27/Parser/tokenizer.c
@@ -1400,20 +1400,22 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
         /* This is a type comment if we matched all of type_comment_prefix. */
         if (!*prefix) {
             int is_type_ignore = 1;
+            const char *ignore_end = p + 6;
             tok_backup(tok, c);  /* don't eat the newline or EOF */
 
             type_start = p;
 
-            is_type_ignore = tok->cur >= p + 6 && memcmp(p, "ignore", 6) == 0;
-            p += 6;
-            while (is_type_ignore && p < tok->cur) {
-              if (*p == '#')
-                  break;
-              is_type_ignore = is_type_ignore && (*p == ' ' || *p == '\t');
-              p++;
-            }
+            /* A TYPE_IGNORE is "type: ignore" followed by the end of the token
+             * or anything ASCII and non-alphanumeric. */
+            is_type_ignore = (
+                tok->cur >= ignore_end && memcmp(p, "ignore", 6) == 0
+                && !(tok->cur > ignore_end
+                     && ((unsigned char)ignore_end[0] >= 128 || Py_ISALNUM(ignore_end[0]))));
 
             if (is_type_ignore) {
+                *p_start = (char *) ignore_end;
+                *p_end = tok->cur;
+
                 /* If this type ignore is the only thing on the line, consume the newline also. */
                 if (blankline) {
                     tok_nextc(tok);

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -297,7 +297,10 @@ Ta27AST_FromNode(const node *n, PyCompilerFlags *flags, const char *filename,
                 goto error;
 
             for (i = 0; i < num; i++) {
-                type_ignore_ty ti = TypeIgnore(LINENO(CHILD(ch, i)), arena);
+                string type_comment = new_type_comment(STR(CHILD(ch, i)), &c);
+                if (!type_comment)
+                    goto error;
+                type_ignore_ty ti = TypeIgnore(LINENO(CHILD(ch, i)), type_comment, arena);
                 if (!ti)
                     goto error;
                 asdl_seq_SET(type_ignores, i, ti);
@@ -2431,7 +2434,7 @@ ast_for_print_stmt(struct compiling *c, const node *n)
         dest = ast_for_expr(c, CHILD(n, 2));
         if (!dest)
             return NULL;
-            start = 4;
+        start = 4;
     }
     values_count = (NCH(n) + 1 - start) / 2;
     if (values_count) {

--- a/ast3/Include/Python-ast.h
+++ b/ast3/Include/Python-ast.h
@@ -462,6 +462,7 @@ struct _type_ignore {
     union {
         struct {
             int lineno;
+            string tag;
         } TypeIgnore;
 
     } v;
@@ -668,8 +669,8 @@ alias_ty _Ta3_alias(identifier name, identifier asname, PyArena *arena);
 #define withitem(a0, a1, a2) _Ta3_withitem(a0, a1, a2)
 withitem_ty _Ta3_withitem(expr_ty context_expr, expr_ty optional_vars, PyArena
                           *arena);
-#define TypeIgnore(a0, a1) _Ta3_TypeIgnore(a0, a1)
-type_ignore_ty _Ta3_TypeIgnore(int lineno, PyArena *arena);
+#define TypeIgnore(a0, a1, a2) _Ta3_TypeIgnore(a0, a1, a2)
+type_ignore_ty _Ta3_TypeIgnore(int lineno, string tag, PyArena *arena);
 
 PyObject* Ta3AST_mod2obj(mod_ty t);
 mod_ty Ta3AST_obj2mod(PyObject* ast, PyArena* arena, int mode);

--- a/ast3/Parser/Python.asdl
+++ b/ast3/Parser/Python.asdl
@@ -130,5 +130,5 @@ module Python
 
     withitem = (expr context_expr, expr? optional_vars)
 
-    type_ignore = TypeIgnore(int lineno)
+    type_ignore = TypeIgnore(int lineno, string tag)
 }

--- a/ast3/Parser/parsetok.c
+++ b/ast3/Parser/parsetok.c
@@ -216,7 +216,8 @@ growable_comment_array_add(growable_comment_array *arr, int lineno, char *commen
 
 static void
 growable_comment_array_deallocate(growable_comment_array *arr) {
-    for (unsigned i = 0; i < arr->num_items; i++) {
+    unsigned i;
+    for (i = 0; i < arr->num_items; i++) {
         PyObject_FREE(arr->items[i].comment);
     }
     free(arr->items);

--- a/ast3/Parser/tokenizer.c
+++ b/ast3/Parser/tokenizer.c
@@ -1536,20 +1536,22 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
         /* This is a type comment if we matched all of type_comment_prefix. */
         if (!*prefix) {
             int is_type_ignore = 1;
+            const char *ignore_end = p + 6;
             tok_backup(tok, c);  /* don't eat the newline or EOF */
 
             type_start = p;
 
-            is_type_ignore = tok->cur >= p + 6 && memcmp(p, "ignore", 6) == 0;
-            p += 6;
-            while (is_type_ignore && p < tok->cur) {
-              if (*p == '#')
-                  break;
-              is_type_ignore = is_type_ignore && (*p == ' ' || *p == '\t');
-              p++;
-            }
+            /* A TYPE_IGNORE is "type: ignore" followed by the end of the token
+             * or anything ASCII and non-alphanumeric. */
+            is_type_ignore = (
+                tok->cur >= ignore_end && memcmp(p, "ignore", 6) == 0
+                && !(tok->cur > ignore_end
+                     && ((unsigned char)ignore_end[0] >= 128 || Py_ISALNUM(ignore_end[0]))));
 
             if (is_type_ignore) {
+                *p_start = (char *) ignore_end;
+                *p_end = tok->cur;
+
                 /* If this type ignore is the only thing on the line, consume the newline also. */
                 if (blankline) {
                     tok_nextc(tok);

--- a/ast3/Python/Python-ast.c
+++ b/ast3/Python/Python-ast.c
@@ -525,8 +525,10 @@ static char *withitem_fields[]={
 static PyTypeObject *type_ignore_type;
 static PyObject* ast2obj_type_ignore(void*);
 static PyTypeObject *TypeIgnore_type;
+_Py_IDENTIFIER(tag);
 static char *TypeIgnore_fields[]={
     "lineno",
+    "tag",
 };
 
 
@@ -1213,7 +1215,7 @@ static int init_types(void)
     if (!type_ignore_type) return 0;
     if (!add_attributes(type_ignore_type, NULL, 0)) return 0;
     TypeIgnore_type = make_type("TypeIgnore", type_ignore_type,
-                                TypeIgnore_fields, 1);
+                                TypeIgnore_fields, 2);
     if (!TypeIgnore_type) return 0;
     initialized = 1;
     return 1;
@@ -2658,14 +2660,20 @@ withitem(expr_ty context_expr, expr_ty optional_vars, PyArena *arena)
 }
 
 type_ignore_ty
-TypeIgnore(int lineno, PyArena *arena)
+TypeIgnore(int lineno, string tag, PyArena *arena)
 {
     type_ignore_ty p;
+    if (!tag) {
+        PyErr_SetString(PyExc_ValueError,
+                        "field tag is required for TypeIgnore");
+        return NULL;
+    }
     p = (type_ignore_ty)PyArena_Malloc(arena, sizeof(*p));
     if (!p)
         return NULL;
     p->kind = TypeIgnore_kind;
     p->v.TypeIgnore.lineno = lineno;
+    p->v.TypeIgnore.tag = tag;
     return p;
 }
 
@@ -4128,6 +4136,11 @@ ast2obj_type_ignore(void* _o)
         value = ast2obj_int(o->v.TypeIgnore.lineno);
         if (!value) goto failed;
         if (_PyObject_SetAttrId(result, &PyId_lineno, value) == -1)
+            goto failed;
+        Py_DECREF(value);
+        value = ast2obj_string(o->v.TypeIgnore.tag);
+        if (!value) goto failed;
+        if (_PyObject_SetAttrId(result, &PyId_tag, value) == -1)
             goto failed;
         Py_DECREF(value);
         break;
@@ -8591,6 +8604,7 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
     }
     if (isinstance) {
         int lineno;
+        string tag;
 
         if (lookup_attr_id(obj, &PyId_lineno, &tmp) < 0) {
             return 1;
@@ -8605,7 +8619,20 @@ obj2ast_type_ignore(PyObject* obj, type_ignore_ty* out, PyArena* arena)
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
         }
-        *out = TypeIgnore(lineno, arena);
+        if (lookup_attr_id(obj, &PyId_tag, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"tag\" missing from TypeIgnore");
+            return 1;
+        }
+        else {
+            int res;
+            res = obj2ast_string(tmp, &tag, arena);
+            if (res != 0) goto failed;
+            Py_CLEAR(tmp);
+        }
+        *out = TypeIgnore(lineno, tag, arena);
         if (*out == NULL) goto failed;
         return 0;
     }

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -910,7 +910,10 @@ Ta3AST_FromNodeObject(const node *n, PyCompilerFlags *flags,
                 goto out;
 
             for (i = 0; i < num; i++) {
-                type_ignore_ty ti = TypeIgnore(LINENO(CHILD(ch, i)), arena);
+                string type_comment = new_type_comment(STR(CHILD(ch, i)), &c);
+                if (!type_comment)
+                    goto out;
+                type_ignore_ty ti = TypeIgnore(LINENO(CHILD(ch, i)), type_comment, arena);
                 if (!ti)
                    goto out;
                asdl_seq_SET(type_ignores, i, ti);

--- a/tools/update_ast27_asdl
+++ b/tools/update_ast27_asdl
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+
+# Run after changing `Parser/Python.asdl`
+
+PROJ_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+
+python2 ast27/Parser/asdl_c.py -h ast27/Include/ ast27/Parser/Python.asdl
+python2 ast27/Parser/asdl_c.py -c ast27/Python/ ast27/Parser/Python.asdl


### PR DESCRIPTION
This is to allow things like `# type: ignore[E1000]`.
Essentially a backport of GH-13238, GH-13479, and GH-13504 from cpython.