### PR TITLE
Fix compilation on Python 3.8

### DIFF
--- a/ast27/Custom/typed_ast.c
+++ b/ast27/Custom/typed_ast.c
@@ -7,6 +7,7 @@
 #include "ast.h"
 #include "parsetok.h"
 #include "errcode.h"
+#include "graminit.h"
 
 extern grammar _Ta27Parser_Grammar; /* from graminit.c */
 
@@ -264,7 +265,7 @@ ast27_parse_impl(PyObject *source,
     const char *str;
     int compile_mode = -1;
     PyCompilerFlags cf;
-    int start[] = {Py_file_input, Py_eval_input, Py_single_input /*, Py_func_type_input */};
+    int start[] = {file_input, eval_input, single_input, func_type_input };
     PyObject *result;
 
     cf.cf_flags = PyCF_ONLY_AST | PyCF_SOURCE_IS_UTF8;

--- a/ast3/Custom/typed_ast.c
+++ b/ast3/Custom/typed_ast.c
@@ -1,12 +1,12 @@
 #include "Python.h"
 #include "Python-ast.h"
-#include "compile-ast3.h"
 #include "node.h"
 #include "grammar.h"
 #include "token.h"
 #include "ast.h"
 #include "parsetok.h"
 #include "errcode.h"
+#include "graminit.h"
 
 extern grammar _Ta3Parser_Grammar; /* from graminit.c */
 
@@ -302,7 +302,7 @@ ast3_parse_impl(PyObject *source,
     const char *str;
     int compile_mode = -1;
     PyCompilerFlags cf;
-    int start[] = {Py_file_input, Py_eval_input, Py_single_input, Py_func_type_input};
+    int start[] = {file_input, eval_input, single_input, func_type_input};
     PyObject *result;
 
     cf.cf_flags = PyCF_ONLY_AST | PyCF_SOURCE_IS_UTF8;

--- a/ast3/Include/compile-ast3.h
+++ b/ast3/Include/compile-ast3.h
@@ -1,6 +1,0 @@
-/* These definitions must match corresponding definitions in graminit.h.
-   There's code in compile.c that checks that they are the same. */
-#define Py_single_input 256
-#define Py_file_input 257
-#define Py_eval_input 258
-#define Py_func_type_input 343

--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -17,7 +17,7 @@ typedef int bool;
 #define false 0
 #define true 1
 
-#ifndef _PyObject_FastCall
+#if PY_MINOR_VERSION < 6
 static PyObject *
 _PyObject_FastCall(PyObject *func, PyObject *const *args, int nargs)
 {


### PR DESCRIPTION
Two things to do this:
 * Use a version check (instead of a macro definedness check) to determine
   whether to emulate _PyObject_FastCall
 * Use the graminit.h versions of Py_func_type_input and friends
   directly instead of defining them in a compile-ast3.h, since
   Py_func_type_input showed back up in a public header with a
   different value in 3.8 and caused warnings.