### PR TITLE
FIX: build on cpython master branch

### DIFF
--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -4531,8 +4531,14 @@ decode_bytes_with_escapes(struct compiling *c, const node *n, const char *s,
                           size_t len)
 {
     const char *first_invalid_escape;
+
+    #if PY_MINOR_VERSION < 9
     PyObject *result = _PyBytes_DecodeEscape(s, len, NULL, 0, NULL,
                                              &first_invalid_escape);
+    #else
+    PyObject *result = _PyBytes_DecodeEscape(s, len, NULL,
+                                             &first_invalid_escape);
+    #endif
     if (result == NULL)
         return NULL;
 


### PR DESCRIPTION
https://github.com/python/cpython/pull/16013 / https://github.com/python/cpython/commit/3a4f66707e824ef3a8384827590ebaa6ca463dc0

removed two arguments from _PyBytes_DecodeEscape .

This calls _PyBytes_DecodeEscape with the new signature if the minor version is 9 or greater.

Followed the convention of only checking minor versions from earlier in the code.