### PR TITLE
Travis CI: Test Python 3.9 release candidate 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Run unit tests and build Linux wheels with manylinux.
 # See: https://github.com/pypa/manylinux
 
+os: linux
+
 dist: xenial
 
 language: python
@@ -68,7 +70,6 @@ deploy:
   secret_access_key: "$GOOGLE_SECRET_KEY"
   bucket: "$GOOGLE_BUCKET_NAME"
   local_dir: wheelhouse
-  skip_cleanup: true
   acl: public-read
   on:
     repo: python/typed_ast

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ python:
   - 3.5
   - 3.6
   - 3.7
-  - 3.8-dev
+  - 3.8
+  - 3.9-dev
 
 script:
   - pytest


### PR DESCRIPTION
https://www.python.org/download/pre-releases/

Also, address Travis build config validation issues:
* `skip_cleanup` is now deprecated https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release
<img width="527" alt="Screenshot 2020-09-06 at 08 49 24 (2)" src="https://user-images.githubusercontent.com/3709715/92320098-22fed580-f01f-11ea-9593-6d04da897b8c.png">
