### PR TITLE
ast27: prefix exported symbols

### DIFF
--- a/ast27/Include/asdl.h
+++ b/ast27/Include/asdl.h
@@ -28,11 +28,11 @@ typedef struct {
 } asdl_int_seq;
 
 #if PY_MINOR_VERSION > 3
-#define asdl_seq_new _Py_asdl_seq_new
-#define asdl_int_seq_new _Py_asdl_int_seq_new
+#define asdl_seq_new _Ta27_asdl_seq_new
+#define asdl_int_seq_new _Ta27_asdl_int_seq_new
 #else
-#define _Py_asdl_seq_new asdl_seq_new
-#define _Py_asdl_int_seq_new asdl_int_seq_new
+#define _Ta27_asdl_seq_new asdl_seq_new
+#define _Ta27_asdl_int_seq_new asdl_int_seq_new
 #endif
 asdl_seq *asdl_seq_new(Py_ssize_t size, PyArena *arena);
 asdl_int_seq *asdl_int_seq_new(Py_ssize_t size, PyArena *arena);

--- a/ast27/Include/asdl.h
+++ b/ast27/Include/asdl.h
@@ -27,13 +27,8 @@ typedef struct {
     int elements[1];
 } asdl_int_seq;
 
-#if PY_MINOR_VERSION > 3
 #define asdl_seq_new _Ta27_asdl_seq_new
 #define asdl_int_seq_new _Ta27_asdl_int_seq_new
-#else
-#define _Ta27_asdl_seq_new asdl_seq_new
-#define _Ta27_asdl_int_seq_new asdl_int_seq_new
-#endif
 asdl_seq *asdl_seq_new(Py_ssize_t size, PyArena *arena);
 asdl_int_seq *asdl_int_seq_new(Py_ssize_t size, PyArena *arena);
 

--- a/ast27/Python/asdl.c
+++ b/ast27/Python/asdl.c
@@ -2,7 +2,7 @@
 #include "../Include/asdl.h"
 
 asdl_seq *
-_Py_asdl_seq_new(Py_ssize_t size, PyArena *arena)
+_Ta27_asdl_seq_new(Py_ssize_t size, PyArena *arena)
 {
     asdl_seq *seq = NULL;
     size_t n;
@@ -33,7 +33,7 @@ _Py_asdl_seq_new(Py_ssize_t size, PyArena *arena)
 }
 
 asdl_int_seq *
-_Py_asdl_int_seq_new(Py_ssize_t size, PyArena *arena)
+_Ta27_asdl_int_seq_new(Py_ssize_t size, PyArena *arena)
 {
     asdl_int_seq *seq = NULL;
     size_t n;

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -292,7 +292,7 @@ Ta27AST_FromNode(const node *n, PyCompilerFlags *flags, const char *filename,
             ch = CHILD(n, NCH(n) - 1);
             REQ(ch, ENDMARKER);
             num = NCH(ch);
-            type_ignores = _Py_asdl_seq_new(num, arena);
+            type_ignores = _Ta27_asdl_seq_new(num, arena);
             if (!type_ignores)
                 goto error;
 
@@ -368,7 +368,7 @@ Ta27AST_FromNode(const node *n, PyCompilerFlags *flags, const char *filename,
                         num++;
                 }
 
-                argtypes = _Py_asdl_seq_new(num, arena);
+                argtypes = _Ta27_asdl_seq_new(num, arena);
 
                 j = 0;
                 for (i = 0; i < NCH(ch); i++) {
@@ -381,7 +381,7 @@ Ta27AST_FromNode(const node *n, PyCompilerFlags *flags, const char *filename,
                 }
             }
             else
-                argtypes = _Py_asdl_seq_new(0, arena);
+                argtypes = _Ta27_asdl_seq_new(0, arena);
 
             ret = ast_for_expr(&c, CHILD(n, NCH(n) - 1));
             if (!ret)


### PR DESCRIPTION
Fixes #151 and (probably) fixes #139

Linking shenanigans caused ast27 to link against Python's `asdl.c`, instead of `ast27/Python/asdl.c`. Python's `asdl.c` uses `Py_ssize_t` for `asdl_seq`'s size whereas `ast27/Python/asdl.c` uses `int`. This means we were interpreting memory differently in `asdl.c` and `ast.c`. On 64-bit big-endian systems, this caused us to misplace `asdl.c`'s writes to `asdl_seq->size`, since `Py_ssize_t` is eight bytes, but `int` is four. The fix mirrors what we do in ast3, that is, manually namespace definitions to avoid linking conflicts.