### PR TITLE
Allow compilation on python 3.10.0a6

### DIFF
--- a/ast27/Parser/tokenizer.c
+++ b/ast27/Parser/tokenizer.c
@@ -18,12 +18,6 @@
 #include "abstract.h"
 #endif /* PGEN */
 
-#if PY_MINOR_VERSION >= 10
-#include "cpython/pydebug.h"
-#else
-#include "pydebug.h"
-#endif
-
 #if PY_MINOR_VERSION >= 4
 PyAPI_FUNC(char *) PyOS_Readline(FILE *, FILE *, const char *);
 #else

--- a/ast27/Parser/tokenizer.c
+++ b/ast27/Parser/tokenizer.c
@@ -16,8 +16,13 @@
 #include "fileobject.h"
 #include "codecs.h"
 #include "abstract.h"
-#include "pydebug.h"
 #endif /* PGEN */
+
+#if PY_MINOR_VERSION >= 10
+#include "cpython/pydebug.h"
+#else
+#include "pydebug.h"
+#endif
 
 #if PY_MINOR_VERSION >= 4
 PyAPI_FUNC(char *) PyOS_Readline(FILE *, FILE *, const char *);

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -13,12 +13,6 @@
 #include "../Include/graminit.h"
 #include "unicodeobject.h"
 
-#if PY_MINOR_VERSION >= 10
-#include "cpython/pyarena.h"
-#else
-#include "pyarena.h"
-#endif
-
 #include <assert.h>
 
 /* Data structure used internally */

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -7,12 +7,17 @@
 #include "../Include/Python-ast.h"
 #include "../Include/grammar.h"
 #include "../Include/node.h"
-#include "pyarena.h"
 #include "../Include/ast.h"
 #include "../Include/token.h"
 #include "../Include/parsetok.h"
 #include "../Include/graminit.h"
 #include "unicodeobject.h"
+
+#if PY_MINOR_VERSION >= 10
+#include "cpython/pyarena.h"
+#else
+#include "pyarena.h"
+#endif
 
 #include <assert.h>
 


### PR DESCRIPTION
It seems that pydebug.h and pyarena.h were moved from /Include/ to /Include/cpython/ in the latest 3.10 alpha (a6).