### PR TITLE
Define _PyUnicode_DecodeUnicodeEscape even on Python 3.6+

### DIFF
--- a/ast3/Python/ast.c
+++ b/ast3/Python/ast.c
@@ -56,6 +56,8 @@ _PyBytes_DecodeEscape(const char *s,
     return PyBytes_DecodeEscape(s, len, errors, unicode, recode_encoding);
 }
 
+#endif
+
 PyObject *
 _PyUnicode_DecodeUnicodeEscape(const char *s,
                                Py_ssize_t size,
@@ -65,8 +67,6 @@ _PyUnicode_DecodeUnicodeEscape(const char *s,
     *first_invalid_escape = NULL;
     return PyUnicode_DecodeUnicodeEscape(s, size, errors);
 }
-
-#endif
 
 static int validate_stmts(asdl_seq *);
 static int validate_exprs(asdl_seq *, expr_context_ty, int);


### PR DESCRIPTION
Fixes https://github.com/python/typed_ast/issues/169

~I have tested this on 3.9.8, 3.9.7 and 3.10.0 only.~ The CI tested this more.