### PR TITLE
Fix Python 3.11 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,21 @@ name: Build wheels
 on: [push, pull_request]
 
 jobs:
+  test_prerelease_python:
+    # needed because manylinux is hesitant to support pre-release python
+    # so we can't just use cibuildwheel
+    name: prelease python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11-dev'
+      - run: |
+          python3.11 -m pip install -e .
+          python3.11 -m pip install pytest
+          python3.11 -m pytest
+
   build_wheels:
     name: py${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/ast3/Parser/tokenizer.c
+++ b/ast3/Parser/tokenizer.c
@@ -1980,6 +1980,8 @@ Ta3Tokenizer_Get(struct tok_state *tok, char **p_start, char **p_end)
    The char* returned is malloc'ed via PyMem_MALLOC() and thus must be freed
    by the caller. */
 
+PyAPI_FUNC(int) _Py_dup(int fd);
+
 char *
 Ta3Tokenizer_FindEncodingFilename(int fd, PyObject *filename)
 {


### PR DESCRIPTION
The compilation error on master is:
```
    ast3/Parser/tokenizer.c:1991:10: error: implicit declaration of function '_Py_dup' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        fd = _Py_dup(fd);
             ^
    1 error generated.
```
Probably as a result of https://github.com/python/cpython/pull/30484

Just declaring it seems to fix things.

Add a (slightly) hacky way of testing Python 3.11 in CI prior to manylinux / cibuildwheel support.