### PR TITLE
BLD: do not include now private header files

### DIFF
--- a/ast27/Include/compile.h
+++ b/ast27/Include/compile.h
@@ -2,7 +2,7 @@
 #ifndef Ta27_COMPILE_H
 #define Ta27_COMPILE_H
 
-#include "code.h"
+#include "Python.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
As of https://github.com/python/cpython/pull/32385 the header
code.h is private but directly included into Python.h