### PR TITLE
Upgrade cibuildwheel - Add Python 3.11 & musllinux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,21 +3,6 @@ name: Build wheels
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  test_prerelease_python:
-    # needed because manylinux is hesitant to support pre-release python
-    # so we can't just use cibuildwheel
-    name: prelease python
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.11-dev'
-      - run: |
-          python3.11 -m pip install -e .
-          python3.11 -m pip install pytest
-          python3.11 -m pytest
-
   build_wheels:
     name: py${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -27,30 +12,24 @@ jobs:
         # cibuildwheel builds linux wheels inside a manylinux container
         # it also takes care of procuring the correct python version for us
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [36, 37, 38, 39, 310]
+        python-version: [36, 37, 38, 39, 310, 311]
+
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: "3.9"
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install "cibuildwheel==2.1.3"
+      - uses: actions/checkout@v3
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.10.2
         env:
           CIBW_BUILD: "cp${{ matrix.python-version }}-*"
-          CIBW_SKIP: "*-manylinux_i686 *-win32"
+          CIBW_SKIP: "*-manylinux_i686 *-musllinux_i686 *-win32"
           CIBW_ARCHS_MACOS: "x86_64 arm64"
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_TEST: pip install pytest
           CIBW_TEST_COMMAND: pytest {package}
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: ./wheelhouse/*.whl
+
   build_wheels_aarch64:
     name: py${{ matrix.python-version }} on ${{ matrix.os }} (aarch64)
     runs-on: ${{ matrix.os }}
@@ -60,40 +39,33 @@ jobs:
         # cibuildwheel builds linux wheels inside a manylinux container
         # it also takes care of procuring the correct python version for us
         os: [ubuntu-latest]
-        python-version: [36, 37, 38, 39, 310]
+        python-version: [36, 37, 38, 39, 310, 311]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: "3.9"
+      - uses: actions/checkout@v3
       - name: Setup up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install "cibuildwheel==2.1.3"
       - name: Build wheels
+        uses: pypa/cibuildwheel@v2.10.2
         env:
           CIBW_BUILD: "cp${{ matrix.python-version }}-*"
           CIBW_ARCHS: aarch64
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BEFORE_TEST: pip install pytest
           CIBW_TEST_COMMAND: pytest {package}
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse .
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: ./wheelhouse/*.whl
+
   build_sdist_python_wheel:
     name: sdist and python wheel
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         name: Install Python
         with:
           python-version: "3.9"
@@ -105,7 +77,7 @@ jobs:
         run: |
           pip install --upgrade setuptools pip wheel
           python setup.py sdist
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: |


### PR DESCRIPTION
- Upgrade GitHub Action versions.
- Employ cibuildwheel action instead of manual setup.
- This upgrade also changes the manylinux image to **manylinux2014** (2010 is EOL and has no 3.11 support).